### PR TITLE
Add .join('') to entries array

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ app.get("/", (request, response) => {
                 <input type="submit" name="submit"></input>
             </form>
             <ul>
-                ${entries.map((value) => "<li>" + value + "</li>")}
+                ${entries.map((value) => "<li>" + value + "</li>").join('')}
             </ul>
         </body>
     </html>


### PR DESCRIPTION
Join the entries array into a string in order to show the list items properly and get rid of the comma between <li>